### PR TITLE
fix 1.4 compiler warnings

### DIFF
--- a/lib/bunt.ex
+++ b/lib/bunt.ex
@@ -26,7 +26,7 @@ defmodule Bunt do
     |> ANSI.format
   end
 
-  def start(_, _), do: {:ok, self}
+  def start(_, _), do: {:ok, self()}
 
   def version, do: @version
 

--- a/lib/bunt_ansi.ex
+++ b/lib/bunt_ansi.ex
@@ -441,7 +441,7 @@ defmodule Bunt.ANSI do
       [[[[[[], "Hello, "] | "\e[31m"] | "\e[1m"], "world!"] | "\e[0m"]
 
   """
-  def format(chardata, emit \\ enabled?) when is_boolean(emit) do
+  def format(chardata, emit \\ enabled?()) when is_boolean(emit) do
     do_format(chardata, [], [], emit, :maybe)
   end
 
@@ -461,7 +461,7 @@ defmodule Bunt.ANSI do
       [[[[[[] | "\e[1m"], 87], 111], 114], 100]
 
   """
-  def format_fragment(chardata, emit \\ enabled?) when is_boolean(emit) do
+  def format_fragment(chardata, emit \\ enabled?()) when is_boolean(emit) do
     do_format(chardata, [], [], emit, false)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Bunt.Mixfile do
       elixir: "~> 1.1",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      deps: deps,
+      deps: deps(),
       name: "Bunt",
       description: "256 color ANSI coloring in the terminal",
       package: [


### PR DESCRIPTION
Nothing urgent, but getting some warnings on compile in 1.4 currently :)
```
$ mix compile                                                                                                                                                                                                                                                                                                                       
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:11

Compiling 2 files (.ex)
warning: variable "self" does not exist and is being expanded to "self()", please use parentheses to remove the ambiguity or change the variable name
  lib/bunt.ex:29

warning: variable "enabled?" does not exist and is being expanded to "enabled?()", please use parentheses to remove the ambiguity or change the variable name
  lib/bunt_ansi.ex:444

warning: variable "enabled?" does not exist and is being expanded to "enabled?()", please use parentheses to remove the ambiguity or change the variable name
  lib/bunt_ansi.ex:464

Generated bunt app
```