### PR TITLE
Make Bunt a library application

### DIFF
--- a/lib/bunt.ex
+++ b/lib/bunt.ex
@@ -1,6 +1,4 @@
 defmodule Bunt do
-  use Application
-
   alias Bunt.ANSI
 
   @version Mix.Project.config[:version]
@@ -30,8 +28,6 @@ defmodule Bunt do
     |> List.flatten
     |> ANSI.format
   end
-
-  def start(_, _), do: {:ok, self()}
 
   def version, do: @version
 

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule Bunt.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [mod: {Bunt, []}, applications: [:logger]]
+    [applications: [:logger]]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
Hi there!

This PR introduces a small fix to make Bunt more OTP compliant. Since Bunt does not require any processes, it was easy to turn it into library application without Application callback module.

The way it was designed before (returning `{:ok, self}` from `Bunt.start/2`) is not working so well with tools which expect OTP compliance.

It is related to erlanglab/erlangpl#43