### PR TITLE
use compile_env in module body

### DIFF
--- a/lib/bunt_ansi.ex
+++ b/lib/bunt_ansi.ex
@@ -298,7 +298,13 @@ defmodule Bunt.ANSI do
     end
   end
 
-  @color_aliases Application.compile_env(:bunt, :color_aliases, [])
+  if apply(Version, :match?, [System.version(), ">= 1.14.0-dev"]) do
+    @color_aliases Application.compile_env(:bunt, :color_aliases, [])
+  else
+    function = :get_env
+    @color_aliases apply(Application, function, [:bunt, :color_aliases, []])
+  end
+
   def color_aliases, do: @color_aliases
 
   for {alias_name, original_name} <- @color_aliases do

--- a/lib/bunt_ansi.ex
+++ b/lib/bunt_ansi.ex
@@ -298,7 +298,7 @@ defmodule Bunt.ANSI do
     end
   end
 
-  @color_aliases Application.get_env(:bunt, :color_aliases, [])
+  @color_aliases Application.compile_env(:bunt, :color_aliases, [])
   def color_aliases, do: @color_aliases
 
   for {alias_name, original_name} <- @color_aliases do


### PR DESCRIPTION
Fixes the below warning

```
warning: Application.get_env/3 is discouraged in the module body, use Application.compile_env/3 instead
  lib/bunt_ansi.ex:300: Bunt.ANSI
```