### PR TITLE
Import Config instead of using Mix.Config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Config
 
 config :bunt, color_aliases: [_code: :cyan]


### PR DESCRIPTION
Removes a warning